### PR TITLE
Add takedown issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/module-submission.yml
+++ b/.github/ISSUE_TEMPLATE/module-submission.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## PLEASE READ:
+        ## Please read
         - ID must match the id in module.prop
         - Once approved, your module will be added to our repo as http://github.com/magisk-modules-alt-repo/example_module
         - Read all requirements before submit for approval:

--- a/.github/ISSUE_TEMPLATE/module-takedown.yml
+++ b/.github/ISSUE_TEMPLATE/module-takedown.yml
@@ -1,0 +1,43 @@
+name: Module Takedown
+description: Preferred Magisk Module takedown template
+title: "[Takedown] "
+labels: ["takedown"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Only accepted when
+        - Doesn't follow Magisk module format after approval
+        - Is not well maintained after approval
+        - You're (issue author) provided the GitHub author, so we can contact him/she.
+
+  - type: input
+    id: module-id
+    attributes:
+      label: ID
+      placeholder: example_module
+    validations:
+      required: true
+  - type: input
+    id: module-name
+    attributes:
+      label: Name
+      placeholder: Example Module
+    validations:
+      required: true
+  - type: input
+    id: module-link
+    attributes:
+      label: Module repository link
+      placeholder: https://www.github.com/username/repo
+    validations:
+      required: true
+  - type: textarea
+    id: mod-takedown-reas
+    attributes:
+      label: Takedown Reason
+      placeholder: |
+            Module does not follow magisk module format
+            bla bla...
+    validations:
+      required: true


### PR DESCRIPTION
I've added a takedown issue template, because https://github.com/Magisk-Modules-Alt-Repo/King-Tweaks does not follow the Magisk module format.

With the issue it would much easier to take down such modules.